### PR TITLE
oAuth: store token in a file accessible by EOS

### DIFF
--- a/systemuser.sh
+++ b/systemuser.sh
@@ -24,6 +24,18 @@ mkdir -p $SCRATCH_HOME
 echo "This directory is temporary and will be deleted when your SWAN session ends!" > $SCRATCH_HOME/IMPORTANT.txt
 chown -R $USER:$USER $SCRATCH_HOME
 
+# Store the oAuth token given by the spawner inside a file
+# so that EOS can use it
+if [[ ! -z "$ACCESS_TOKEN" ]];
+then
+    log_info "Storing oAuth token for EOS"
+    export OAUTH2_FILE=/tmp/eos_oauth.token
+    export OAUTH2_TOKEN="FILE:$OAUTH2_FILE"
+    echo -n oauth2:$ACCESS_TOKEN:$OAUTH_INSPECTION_ENDPOINT >& $OAUTH2_FILE
+    chown -R $USER:$USER $OAUTH2_FILE
+    chmod 600 $OAUTH2_FILE
+fi
+
 sudo -E -u $USER sh -c 'if [[ ! -d "$SWAN_HOME" || ! -x "$SWAN_HOME" ]]; then exit 1; fi'
 if [ $? -ne 0 ]
 then


### PR DESCRIPTION
We will start using oauth tokens to authenticate to EOS. It's still not enabled in all the EOS instances, but we can start playing with one of them.

Since we need access to the user directory right in the startup script, I've added the logic to create the file that FUSEX uses to read the access token. We will have an extension that will do the update, but this will come as a server extension (swan-cern/jupyter-extensions/issues/27).

Since we will no longer have a kerberos token, we also need to remove the code that creates a separate `KRB5CCNAME`.
@prasanthkothuri I've removed the code in this PR, but I guess it's preferable to keep it for now for the k8s deployment? 