### PR TITLE
Install jupyter-resource-usage in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -200,9 +200,13 @@ ADD etc/krb5.conf.no_rdns  /etc/krb5.conf.no_rdns
 RUN mv /usr/local/lib/python3.9/site-packages/ipykernel /usr/local/lib/python3.9/site-packages/ipykernelBACKUP && \
     mv /usr/local/share/jupyter/kernels /usr/local/share/jupyter/kernelsBACKUP
 
+# Required by jupyter-resource-usage
+RUN pip install psutil==5.8.0
+
 # Install all of our extensions
 # Ignore (almost all) dependencies because they have already been installed or come from CVMFS
 RUN pip install --no-deps \
+            jupyter-resource-usage==0.6.0 \
             hdfsbrowser==1.0.0 \
             sparkconnector==1.1.0 \
             sparkmonitor==1.1.1 \


### PR DESCRIPTION
Added https://github.com/jupyter-server/jupyter-resource-usage, which displays the memory used in the user containers.

- By default periodically polls a serverextension endpoint every 5s to update the information 
<img width="1440" alt="Screenshot 2021-08-27 at 15 10 05" src="https://user-images.githubusercontent.com/6822941/131133245-2703096d-02ae-411f-a43c-bc3398b9144b.png">

<img width="1440" alt="Screenshot 2021-08-27 at 15 12 23" src="https://user-images.githubusercontent.com/6822941/131133255-6d1d22c2-d5b3-415b-a042-5144d3b6fa8d.png">
