### PR TITLE
Configure Jupyterlab SparkConnector and SparkMonitor v2.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN yum -y install \
     libXpm \
     libXft
 
-# Install bs4 - required by sparkconnector.serverextension
+# Install bs4 - required by hdfsbrowser
 RUN pip3 install bs4
 
 # Install tk - required by matplotlib
@@ -223,7 +223,6 @@ RUN pip install --no-deps \
     jupyter nbextension install --py --system sparkconnector && \
     jupyter nbextension install --py --system sparkmonitor && \
     jupyter nbextension enable --py --system sparkmonitor && \
-    jupyter serverextension enable --py --system sparkmonitor && \
     jupyter nbextension install --py --system swancontents && \
     jupyter serverextension enable --py --system swancontents && \
     jupyter nbextension install --py --system swanhelp && \

--- a/systemuser.sh
+++ b/systemuser.sh
@@ -194,6 +194,16 @@ then
   echo "c.HDFSBrowserConfig.hdfs_site_path = '/cvmfs/sft.cern.ch/lcg/etc/hadoop-confext/conf/etc/$CLUSTER_NAME/hadoop.$CLUSTER_NAME/hdfs-site.xml'" >> $JPY_CONFIG
   echo "c.HDFSBrowserConfig.hdfs_site_namenodes_property = 'dfs.ha.namenodes.$NAMESPACE'" >> $JPY_CONFIG
   echo "c.HDFSBrowserConfig.hdfs_site_namenodes_port = '50070'" >> $JPY_CONFIG
+
+else 
+  # Disable spark jupyterlab extensions enabled by default if no cluster is selected
+  mkdir -p /etc/jupyter/labconfig
+  echo "{
+    \"disabledExtensions\": {
+      \"sparkconnector\": true,
+      \"sparkmonitor\": true
+    }
+  }" > /etc/jupyter/labconfig/page_config.json
 fi
 
 # HTCondor at CERN integration


### PR DESCRIPTION
- Remove installing serverextension for sparkmonitor 2.x
- Disable sparkmonitor and sparkconnector lab extensions (similar to notebook extensions) if no cluster is selected.