### PR TITLE
Disable sparkmonitor and hdfsbrowser jupyterlab

### DIFF
--- a/systemuser.sh
+++ b/systemuser.sh
@@ -201,7 +201,8 @@ else
   echo "{
     \"disabledExtensions\": {
       \"sparkconnector\": true,
-      \"sparkmonitor\": true
+      \"@swan-cern/hdfsbrowser\": true,
+      \"jupyterlab_sparkmonitor\": true
     }
   }" > /etc/jupyter/labconfig/page_config.json
 fi


### PR DESCRIPTION
Disable spark extensions if cluster is not selected. Note disabling only seems to work with `extension.id` as key not the package name.