### PR TITLE
Install Dask lab extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -203,9 +203,14 @@ RUN mv /usr/local/lib/python3.9/site-packages/ipykernel /usr/local/lib/python3.9
 # Required by jupyter-resource-usage
 RUN pip install psutil==5.8.0
 
+# Required by dask-labextension
+RUN pip install jupyter-server-proxy==3.2.1 \
+                simpervisor==0.4
+
 # Install all of our extensions
 # Ignore (almost all) dependencies because they have already been installed or come from CVMFS
 RUN pip install --no-deps --no-cache-dir \
+            dask-labextension==5.2.0 \
             jupyter-resource-usage==0.6.0 \
             hdfsbrowser==1.1.1 \
             sparkconnector==2.3.0 \


### PR DESCRIPTION
To manage e.g. HTCondor and k8s clusters graphically from SWAN.

I tried to test the extension by installing it on CERNBox, but the fact that we now start the notebook server with `python -s` prevents it from being picked (as pointed out by @krishnan-r).