### PR TITLE
No need to enable portallocator extension just for Spark

### DIFF
--- a/systemuser.sh
+++ b/systemuser.sh
@@ -184,7 +184,6 @@ then
   echo "{
     \"NotebookApp\": {
       \"nbserver_extensions\": {
-        \"swanportallocator.portallocator\": true,
         \"hdfsbrowser.serverextension\": true
       }
     }


### PR DESCRIPTION
The portallocator extension can be always enabled, no matter
if the user selects to work with Spark/HTCondor or not.
The extension is resilient to the SPARK_PORTS variable not
being set. Actually, already now the extension is always
enabled in the Dockerfile, so the line removed by this
commit is redundant.