### PR TITLE
Make _xsrf cookie a session cookie

### DIFF
--- a/systemuser.sh
+++ b/systemuser.sh
@@ -106,6 +106,16 @@ echo "c.SwanOauthRenew.files = [
     ('$OAUTH2_FILE', 'exchanged_tokens/$EOS_OAUTH_ID', 'oauth2:{token}:$OAUTH_INSPECTION_ENDPOINT')
 ]" >> $JPY_CONFIG
 
+# Convert the _xsrf cookie into a session cookie, to prevent it from having an expiration date of 30 days
+# Without this setting, _xsrf cookie could expire in the middle of a user editing a notebook, making it
+# impossible to save the notebook without refreshing the page and losing unsaved changes.
+echo "c.NotebookApp.tornado_settings = {
+  'xsrf_cookie_kwargs': {
+    'expires_days': None,
+    'expires': None
+  }
+}" >> $JPY_CONFIG
+
 cp -L -r $LCG_VIEW/etc/jupyter/* $JUPYTER_CONFIG_DIR
 
 # Configure %%cpp cell highlighting


### PR DESCRIPTION
The _xsrf cookie currently expires in 30 days, potentially in the middle of a user session. This causes notebooks to fail to save until the page is refreshed, which means the user loses unsaved work.

Since _xsrf cookie is set by the tornado server in jupyter-notebook. This commit specifies two tornado settings to disable the expiration date being set in the cookie

The _xsrf cookie does not perform any authentication and the actual value itself is useless, instead the value of the _xsrf cookie is sent in every request POST/PUT/DELETE as a header. The server asserts that the [value in the header is equal to the value in the cookie](https://github.com/tornadoweb/tornado/blob/341e8900524846a2c5e7a9ce5be4448e13d2d3d7/tornado/web.py#L1529), so a malicious js script from a different origin/website cannot guess the header without the cookie and cannot make a request on behalf of the user