### PR TITLE
Fix refreshing of EOS kerberos ticket for notebooks and terminals (part 2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -268,7 +268,6 @@ ENV SHELL /bin/bash
 
 ADD systemuser.sh /srv/singleuser/systemuser.sh
 ADD userconfig.sh /srv/singleuser/userconfig.sh
-ADD userconfig.sh /srv/singleuser/userconfig.sh
 ADD configure_kernels_and_terminal.py /srv/singleuser/configure_kernels_and_terminal.py
 ADD executables/start_ipykernel.py /usr/local/bin/start_ipykernel.py
 RUN chmod 705 /usr/local/bin/start_ipykernel.py


### PR DESCRIPTION
This PR is one of two parts of a fix for refreshing the EOS kerberos ticket that is used by notebooks and terminal processes
in SWAN kubernetes, the other part being some changes in the swan-cern chart (https://github.com/swan-cern/swan-charts/pull/124).

The changes of this PR rely on the `KRB5CCNAME_NB_TERM` variable to be set in k8s to point to the path where the notebook and terminal ticket is stored, which is done by in https://github.com/swan-cern/swan-charts/pull/124.