### PR TITLE
Add URL to SWAN Gallery website to server configuration

### DIFF
--- a/systemuser.sh
+++ b/systemuser.sh
@@ -270,9 +270,14 @@ fi
 
 if [[ $GALLERY_URL ]]
 then
+  # Configure links rendered by notebook pages
   echo "c.NotebookApp.jinja_template_vars = {
     'gallery_url': '$GALLERY_URL'
 }" >> $JPY_CONFIG
+  # Configure SwanGallery JupyterLab extension
+  echo "{
+    \"gallery_url\": \"$GALLERY_URL\"
+}" > /usr/local/etc/jupyter/nbconfig/gallery.json
 fi
 
 # Make sure we have a sane terminal


### PR DESCRIPTION
This allows the jupyterlab extension to query the config section named 'gallery' to obtain the URL for the gallery website that is received as an environment variable from the chart configuration


Needed for:
- https://github.com/swan-cern/swan-charts/pull/128
- https://github.com/swan-cern/mkdocs-swan/pull/2
- https://github.com/swan-cern/jupyter-extensions/pull/307