### PR TITLE
Enable the creation of Dask HTCondor clusters via Dask Lab extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -216,7 +216,7 @@ RUN pip install simpervisor==0.4
 # Ignore (almost all) dependencies because they have already been installed or come from CVMFS
 RUN pip install --no-deps --no-cache-dir \
             dask-labextension==5.2.0 \
-            # swandask must to be installed after its dependency dask-labextension to disable the server extension automatically
+            # swandask must be installed after its dependency dask-labextension to disable the server extension automatically
             swandask==0.0.3 && \
             swandaskcluster==1.0.3 && \
             jupyter-resource-usage==0.6.0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -204,8 +204,13 @@ RUN mv /usr/local/lib/python3.9/site-packages/ipykernel /usr/local/lib/python3.9
 RUN pip install psutil==5.8.0
 
 # Required by dask-labextension
-RUN pip install jupyter-server-proxy==3.2.1 \
-                simpervisor==0.4
+# Jupyter server proxy: we need a commit that is not in 1.6.0 to allow empty PUT body in request
+RUN git clone -b v1.6.0 https://github.com/jupyterhub/jupyter-server-proxy.git /tmp/jupyter-server-proxy && \
+    cd /tmp/jupyter-server-proxy && \
+    git cherry-pick -n e2481b52bdd31865a8fc1cce762a9a12e8846fd9 && \
+    pip install --no-cache-dir /tmp/jupyter-server-proxy && \
+    rm -rf /tmp/jupyter-server-proxy
+RUN pip install simpervisor==0.4
 
 # Install all of our extensions
 # Ignore (almost all) dependencies because they have already been installed or come from CVMFS

--- a/Dockerfile
+++ b/Dockerfile
@@ -218,6 +218,7 @@ RUN pip install --no-deps --no-cache-dir \
             dask-labextension==5.2.0 \
             # swandask must to be installed after its dependency dask-labextension to disable the server extension automatically
             swandask==0.0.3 && \
+            swandaskcluster==1.0.3 && \
             jupyter-resource-usage==0.6.0 \
             hdfsbrowser==1.1.1 \
             sparkconnector==2.4.6 \
@@ -264,6 +265,7 @@ RUN pip install --no-deps --no-cache-dir \
     ln -s /usr/local/lib/python3.9/site-packages/jupyter_server_proxy /usr/local/lib/swan/extensions/ && \
     ln -s /usr/local/lib/python3.9/site-packages/simpervisor /usr/local/lib/swan/extensions/ && \
     ln -s /usr/local/lib/python3.9/site-packages/swandask /usr/local/lib/swan/extensions/ && \
+    ln -s /usr/local/lib/python3.9/site-packages/swandaskcluster /usr/local/lib/swan/extensions/ && \
     # FIXME workaround for templates. For some reason, and only in our image, Jupyter is looking for templates inside templates
     cp -r /usr/local/lib/python3.9/site-packages/swancontents/templates{,2} && \
     mv /usr/local/lib/python3.9/site-packages/swancontents/templates{2,/templates}

--- a/Dockerfile
+++ b/Dockerfile
@@ -216,6 +216,8 @@ RUN pip install simpervisor==0.4
 # Ignore (almost all) dependencies because they have already been installed or come from CVMFS
 RUN pip install --no-deps --no-cache-dir \
             dask-labextension==5.2.0 \
+            # swandask must to be installed after its dependency dask-labextension to disable the server extension automatically
+            swandask==0.0.3 && \
             jupyter-resource-usage==0.6.0 \
             hdfsbrowser==1.1.1 \
             sparkconnector==2.4.6 \
@@ -261,6 +263,7 @@ RUN pip install --no-deps --no-cache-dir \
     ln -s /usr/local/lib/python3.9/site-packages/dask_labextension /usr/local/lib/swan/extensions/ && \
     ln -s /usr/local/lib/python3.9/site-packages/jupyter_server_proxy /usr/local/lib/swan/extensions/ && \
     ln -s /usr/local/lib/python3.9/site-packages/simpervisor /usr/local/lib/swan/extensions/ && \
+    ln -s /usr/local/lib/python3.9/site-packages/swandask /usr/local/lib/swan/extensions/ && \
     # FIXME workaround for templates. For some reason, and only in our image, Jupyter is looking for templates inside templates
     cp -r /usr/local/lib/python3.9/site-packages/swancontents/templates{,2} && \
     mv /usr/local/lib/python3.9/site-packages/swancontents/templates{2,/templates}

--- a/Dockerfile
+++ b/Dockerfile
@@ -258,6 +258,9 @@ RUN pip install --no-deps --no-cache-dir \
     ln -s /usr/local/lib/python3.9/site-packages/sparkconnector /usr/local/lib/swan/extensions/ && \
     ln -s /usr/local/lib/python3.9/site-packages/swankernelenv /usr/local/lib/swan/extensions/ && \
     ln -s /usr/local/lib/python3.9/site-packages/swanportallocator /usr/local/lib/swan/extensions/ && \
+    ln -s /usr/local/lib/python3.9/site-packages/dask_labextension /usr/local/lib/swan/extensions/ && \
+    ln -s /usr/local/lib/python3.9/site-packages/jupyter_server_proxy /usr/local/lib/swan/extensions/ && \
+    ln -s /usr/local/lib/python3.9/site-packages/simpervisor /usr/local/lib/swan/extensions/ && \
     # FIXME workaround for templates. For some reason, and only in our image, Jupyter is looking for templates inside templates
     cp -r /usr/local/lib/python3.9/site-packages/swancontents/templates{,2} && \
     mv /usr/local/lib/python3.9/site-packages/swancontents/templates{2,/templates}


### PR DESCRIPTION
This PR is a first step towards allowing to graphically create Dask HTCondor clusters from SWAN and connect to them.

In particular, it adds the following packages
- [swandask](https://github.com/swan-cern/jupyter-extensions/tree/master/SwanDask)
- [swan-daskcluster](https://github.com/swan-cern/swan-daskcluster)

It also fixes the `jupyter-server-proxy` dependency of the Dask Lab extension, for which we need v1.6.0 patched with https://github.com/jupyterhub/jupyter-server-proxy/commit/e2481b52bdd31865a8fc1cce762a9a12e8846fd9 .

A second step will be to implement TLS to enable secure communication between Dask processes (will come in another PR).