### PR TITLE
Generate self-signed certificate for Dask processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -282,6 +282,7 @@ ENV SHELL /bin/bash
 
 ADD systemuser.sh /srv/singleuser/systemuser.sh
 ADD userconfig.sh /srv/singleuser/userconfig.sh
+ADD create_dask_certs.sh /srv/singleuser/create_dask_certs.sh
 ADD configure_kernels_and_terminal.py /srv/singleuser/configure_kernels_and_terminal.py
 ADD executables/start_ipykernel.py /usr/local/bin/start_ipykernel.py
 RUN chmod 705 /usr/local/bin/start_ipykernel.py

--- a/create_dask_certs.sh
+++ b/create_dask_certs.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+
+# Author: Enric Tejedor 2023
+
+# Generates a self-signed certificate to be used by Dask processes (client,
+# scheduler and workers) within a SWAN session.
+# Dask clusters created from SWAN can be configured with TLS support by
+# pointing to the server certificate, private key and CA certificate that are
+# generated below.
+
+CERT_DIR=$1
+TEMP_DIR=`mktemp -d`
+export RANDFILE="$TEMP_DIR/.rnd"
+
+ORGANIZATIONAL_UNIT="SWAN"
+ORGANIZATION="CERN"
+LOCALITY="Geneva"
+COUNTRY="CH"
+CA_COMMON_NAME="SWAN CA"
+COMMON_NAME="SWAN Dask server"
+
+CA_CERT="ca.crt"
+CA_KEY="ca.key"
+SERVER_CERT="server.crt"
+SERVER_KEY="server.key"
+
+CSR_CONF="csr.conf"
+CSR="server.csr"
+CERT_CONF="cert.conf"
+
+# Create CA private key and certificate
+openssl genrsa -out $CERT_DIR/$CA_KEY 2048
+openssl req -x509 \
+            -sha256 \
+            -days 30 \
+            -nodes \
+            -subj "/CN=$CA_COMMON_NAME/OU=$ORGANIZATIONAL_UNIT/O=$ORGANIZATION/L=$LOCALITY/C=$COUNTRY" \
+            -key $CERT_DIR/$CA_KEY \
+            -out $CERT_DIR/$CA_CERT
+
+# Create server private key
+openssl genrsa -out $CERT_DIR/$SERVER_KEY 2048
+
+# Create certificate signing request configuration
+cat > $TEMP_DIR/$CSR_CONF <<EOF
+[ req ]
+default_bits = 2048
+prompt = no
+default_md = sha256
+distinguished_name = dn
+
+[ dn ]
+C = $COUNTRY
+L = $LOCALITY
+O = $ORGANIZATION
+OU = $ORGANIZATIONAL_UNIT
+CN = $COMMON_NAME
+EOF
+
+# Create certificate signing request
+openssl req -new \
+            -config $TEMP_DIR/$CSR_CONF \
+            -key $CERT_DIR/$SERVER_KEY \
+            -out $TEMP_DIR/$CSR
+
+# Create external config file for the certificate
+cat > $TEMP_DIR/$CERT_CONF <<EOF
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+EOF
+
+# Create self-signed certificate
+openssl x509 -req \
+             -sha256 \
+             -days 30 \
+             -CA $CERT_DIR/$CA_CERT \
+             -CAkey $CERT_DIR/$CA_KEY \
+             -CAcreateserial \
+             -extfile $TEMP_DIR/$CERT_CONF \
+             -in $TEMP_DIR/$CSR \
+             -out $CERT_DIR/$SERVER_CERT
+
+# Cleanup
+rm -rf $TEMP_DIR

--- a/systemuser.sh
+++ b/systemuser.sh
@@ -241,6 +241,13 @@ then
   ln -s /eos/project/l/lxbatch/public/config-condor-swan/config.d/10_cernsubmit.erb /etc/condor/config.d/10_cernsubmit.erb
   ln -s /eos/project/l/lxbatch/public/config-condor-swan/myschedd.yaml /etc/myschedd/myschedd.yaml
   ln -s /eos/project/l/lxbatch/public/config-condor-swan/ngbauth-submit /etc/sysconfig/ngbauth-submit
+
+  # Create self-signed certificate for Dask processes
+  log_info "Generating certificate for Dask"
+  export DASK_TLS_DIR=/srv/dask_tls
+  mkdir -p $DASK_TLS_DIR
+  chown -R $USER:$USER $DASK_TLS_DIR
+  sudo -u $USER sh /srv/singleuser/create_dask_certs.sh $DASK_TLS_DIR
 fi
 
 # Configurations for extensions (used when deployed outside CERN)


### PR DESCRIPTION
This is done per user session, dynamically when the session starts.

The server certificate, private key and CA certificate can be used to implement TLS in Dask clusters (e.g. via SwanHTCondorCluster).

Still missing:
- Only generate the certificate if the user selects "HTCondor cluster" from the form, which is not implemented yet. In other words, the `$CERN_HTCONDOR` variable needs to be set dynamically depending on the user form, instead of always like it is done now.
- Make use of the certificates from `SwanHTCondorCluster`, i.e. the class that we use to create Dask clusters on HTCondor. That class needs to configure TLS with the certificates generated here.