### PR TITLE
Spawn Dask TLS certifice generation as a background process

### DIFF
--- a/systemuser.sh
+++ b/systemuser.sh
@@ -247,7 +247,7 @@ then
   export DASK_TLS_DIR=/srv/dask_tls
   mkdir -p $DASK_TLS_DIR
   chown -R $USER:$USER $DASK_TLS_DIR
-  sudo -u $USER sh /srv/singleuser/create_dask_certs.sh $DASK_TLS_DIR
+  sudo -u $USER sh /srv/singleuser/create_dask_certs.sh $DASK_TLS_DIR &
 fi
 
 # Configurations for extensions (used when deployed outside CERN)


### PR DESCRIPTION
In the future, the TLS certificate generation will only happen when the user selects from the form that they want to work with and HTCondor cluster. Until then, we add it as a background process so that it does not slow down the startup of the user session.