### PR TITLE
Enable the use of a default Security object for Dask

### DIFF
--- a/systemuser.sh
+++ b/systemuser.sh
@@ -244,10 +244,13 @@ then
 
   # Create self-signed certificate for Dask processes
   log_info "Generating certificate for Dask"
-  export DASK_TLS_DIR=/srv/dask_tls
-  mkdir -p $DASK_TLS_DIR
+  export DASK_TLS_DIR=$DASK_DIR/tls
+  mkdir $DASK_TLS_DIR
   chown -R $USER:$USER $DASK_TLS_DIR
   sudo -u $USER sh /srv/singleuser/create_dask_certs.sh $DASK_TLS_DIR &
+
+  # Make SwanHTCondorCluster findable by the Dask lab extension
+  export PYTHONPATH=$PYTHONPATH:$DASK_LIB_DIR
 fi
 
 # Configurations for extensions (used when deployed outside CERN)

--- a/userconfig.sh
+++ b/userconfig.sh
@@ -50,7 +50,14 @@ SETUP_LCG_TIME_SEC=$(echo $(date +%s.%N --date="$START_TIME_SETUP_LCG seconds ag
 log_info "user: $USER, host: ${SERVER_HOSTNAME%%.*}, metric: configure_user_env_cvmfs.${ROOT_LCG_VIEW_NAME:-none}.duration_sec, value: $SETUP_LCG_TIME_SEC"
 
 # Add SWAN modules path to PYTHONPATH so that it picks them
-export PYTHONPATH=/usr/local/lib/swan/extensions/:$PYTHONPATH 
+export PYTHONPATH=/usr/local/lib/swan/extensions/:$PYTHONPATH
+
+# Configure Dask.
+# DASK_LIB_DIR is necessary so that kernels and notebooks can use the loader
+# in swandaskcluster to create a default Security object for Dask clients, to
+# which we point with a Dask variable
+export PYTHONPATH=$PYTHONPATH:$DASK_LIB_DIR
+export DASK_DISTRIBUTED__CLIENT__SECURITY_LOADER="swandaskcluster.security.loader"
 
 # Configure SparkMonitor
 export KERNEL_PROFILEPATH=$PROFILEPATH/ipython_kernel_config.py 


### PR DESCRIPTION
This goes together with some changes in swan-daskcluster to be able to automatically generate a Security object for Dask clients that points to the certificates and keys we generate: https://github.com/swan-cern/swan-daskcluster/pull/9

swan-daskcluster needs to be in the PYTHONPATH of notebooks and terminals because it implements the loader who will create the default Security object, and we point to that loader with a Dask variable.