### PR TITLE
Update name of CERN Grid CA certificate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -177,9 +177,7 @@ ADD etc/grid-security/vomsdir /etc/grid-security/vomsdir
 
 # Create truststore for NXCALS Spark connection
 RUN yum -y install java-1.8.0-openjdk && \
-    keytool -import -alias cerngridCA -file /etc/pki/tls/certs/CERN_Grid_Certification_Authority\(1\).crt \
-        -keystore /etc/pki/tls/certs/truststore.jks -storepass 'password' -noprompt && \
-    keytool -import -alias cernRootCA2 -file /etc/pki/tls/certs/CERN_Root_Certification_Authority_2.crt \
+    keytool -import -alias cernbundle -file /etc/pki/tls/certs/CERN-bundle.crt \
         -keystore /etc/pki/tls/certs/truststore.jks -storepass 'password' -noprompt && \
     yum -y erase java-1.8.0-openjdk && \
     rm -rf /usr/lib/jvm/

--- a/Dockerfile
+++ b/Dockerfile
@@ -177,7 +177,7 @@ ADD etc/grid-security/vomsdir /etc/grid-security/vomsdir
 
 # Create truststore for NXCALS Spark connection
 RUN yum -y install java-1.8.0-openjdk && \
-    keytool -import -alias cerngridCA -file /etc/pki/tls/certs/CERN_Grid_Certification_Authority.crt \
+    keytool -import -alias cerngridCA -file /etc/pki/tls/certs/CERN_Grid_Certification_Authority\(1\).crt \
         -keystore /etc/pki/tls/certs/truststore.jks -storepass 'password' -noprompt && \
     keytool -import -alias cernRootCA2 -file /etc/pki/tls/certs/CERN_Root_Certification_Authority_2.crt \
         -keystore /etc/pki/tls/certs/truststore.jks -storepass 'password' -noprompt && \


### PR DESCRIPTION
The latest update of the CERN-CA-certs package:
https://linux.web.cern.ch/updates/cc7/prod/latest_updates/#2023-04-24
changes the name of the Grid CA certificate.