### PR TITLE
Prevent jupyter server from searching Python modules in SWAN_HOME

### DIFF
--- a/systemuser.sh
+++ b/systemuser.sh
@@ -248,9 +248,6 @@ then
   mkdir $DASK_TLS_DIR
   chown -R $USER:$USER $DASK_TLS_DIR
   sudo -u $USER sh /srv/singleuser/create_dask_certs.sh $DASK_TLS_DIR &
-
-  # Make SwanHTCondorCluster findable by the Dask lab extension
-  export PYTHONPATH=$PYTHONPATH:$DASK_LIB_DIR
 fi
 
 # Configurations for extensions (used when deployed outside CERN)
@@ -323,7 +320,7 @@ fi
 
 log_info "Running the notebook server"
 sudo -E -u $USER sh -c 'cd $SWAN_HOME \
-                        && /usr/local/bin/python3 -s -m jupyterhub.singleuser \
+                        && /usr/local/bin/python3 -I -m jupyterhub.singleuser \
                            --port=8888 \
                            --ip=0.0.0.0 \
                            --user=$JPY_USER \


### PR DESCRIPTION
We replace -s by -I as option to python. -I is both -s and -E, and -E means that no PYTHON* variable will be inherited by the new process (the Jupyter server). It also prevents the current directory to be included in the search path. The latter helps us prevent problems when the user has some module in SWAN_HOME that can interfere with the Jupyter server.

Since we now do -I, no setting of the PYTHONPATH in systemuser.sh will have any effect on the Jupyter server. Anyway, the setting we did to include the Dask libraries in the PYTHONPATH was sterile, because the SwanDask extension wraps the Dask lab extension and uses the environment of the Python3 kernel for it, which already includes the Dask library dir. This is why we remove the aforementioned setting.