### PR TITLE
Add CERN Root CA 2 to truststore.jks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -179,6 +179,10 @@ ADD etc/grid-security/vomsdir /etc/grid-security/vomsdir
 RUN yum -y install java-1.8.0-openjdk && \
     keytool -import -alias cernbundle -file /etc/pki/tls/certs/CERN-bundle.crt \
         -keystore /etc/pki/tls/certs/truststore.jks -storepass 'password' -noprompt && \
+    keytool -import -alias cernGridCA -file "/etc/pki/tls/certs/CERN_Grid_Certification_Authority(1).crt" \
+        -keystore /etc/pki/tls/certs/truststore.jks -storepass 'password' -noprompt && \
+    keytool -import -alias cernRootCA2 -file "/etc/pki/tls/certs/CERN_Root_Certification_Authority_2.crt" \
+        -keystore /etc/pki/tls/certs/truststore.jks -storepass 'password' -noprompt && \
     yum -y erase java-1.8.0-openjdk && \
     rm -rf /usr/lib/jvm/
 


### PR DESCRIPTION
- This PR adds `CERN_Grid_Certification_Authority(1).crt` and `CERN_Grid_Certification_Authority(1).crt` to a JKS file located at `/etc/pki/tls/certs/truststore.jks`.
- It is necessary in preparation for the Spark Connect connector extension, as the inclusion of this certificate would allow Spark Web UI to trust the Analytix Hadoop master proxy and allow the local Web UI installation to send a redirect.
- However, this PR only adds the certificate to a truststore file. The Spark driver still needs to be configured to use the file as a trust store using the `spark.driver.extraJavaOptions` option.
    - i.e. `spark.driver.extraJavaOptions=-Djavax.net.ssl.trustStore=/etc/ssl/certs/truststore.jks -Djavax.net.ssl.trustStorePassword=password` 
- It would be nice if we could have this option enabled globally, but setting `JAVA_OPTS` and `SPARK_JAVA_OPTS` didn't seem to work, cc @etejedor @diocas 