### PR TITLE
Update to latest base with newer JH 4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -278,5 +278,10 @@ ADD configure_kernels_and_terminal.py /srv/singleuser/configure_kernels_and_term
 ADD executables/start_ipykernel.py /usr/local/bin/start_ipykernel.py
 RUN chmod 705 /usr/local/bin/start_ipykernel.py
 
+# TEMPORARY: apply a patch to the auth file while we wait for the release of a new version with it
+ADD log_patch.diff /tmp/log_patch.diff
+RUN patch /usr/local/lib/python3.9/site-packages/jupyterhub/services/auth.py /tmp/log_patch.diff && \
+    rm -f /tmp/log_patch.diff
+
 WORKDIR /root
 CMD ["sh", "/srv/singleuser/systemuser.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Analogous to jupyter/systemuser, but based on CC7 and inheriting directly from cernphsft/notebook.
 # Run with the DockerSpawner in JupyterHub.
 
-FROM gitlab-registry.cern.ch/swan/docker-images/notebook:v7.6.1
+FROM gitlab-registry.cern.ch/swan/docker-images/notebook:v8.0.1
 
 LABEL maintainer="swan-admins@cern.ch"
 

--- a/log_patch.diff
+++ b/log_patch.diff
@@ -1,0 +1,11 @@
+--- ./jupyterhub/services/auth.py  2023-08-17 12:28:41.000000000 +0200
++++ ./jupyterhub/services/auth.py 2023-10-11 12:20:20.597042884 +0200
+@@ -1229,6 +1229,7 @@
+         )
+         if user_model is None:
+             raise HTTPError(500, "oauth callback failed to identify a user")
+-        app_log.info("Logged-in user %s", user_model)
++        app_log.info("Logged-in user %s", user_model['name'])
++        app_log.debug("User model %s", user_model)
+         self.hub_auth.set_cookie(self, token)
+         self.redirect(next_url or self.hub_auth.base_url)

--- a/systemuser.sh
+++ b/systemuser.sh
@@ -331,6 +331,8 @@ fi
 # including loading any .pth files which modify sys.path
 
 log_info "Running the notebook server"
+# Force the old backend, since the newer version uses jupyter-server by default
+export JUPYTERHUB_SINGLEUSER_APP='notebook'
 sudo -E -u $USER sh -c 'cd $SWAN_HOME \
                         && /usr/local/bin/python3 -I -m jupyterhub.singleuser \
                            --port=8888 \

--- a/systemuser.sh
+++ b/systemuser.sh
@@ -334,11 +334,4 @@ log_info "Running the notebook server"
 # Force the old backend, since the newer version uses jupyter-server by default
 export JUPYTERHUB_SINGLEUSER_APP='notebook'
 sudo -E -u $USER sh -c 'cd $SWAN_HOME \
-                        && /usr/local/bin/python3 -I -m jupyterhub.singleuser \
-                           --port=8888 \
-                           --ip=0.0.0.0 \
-                           --user=$JPY_USER \
-                           --cookie-name=$JPY_COOKIE_NAME \
-                           --base-url=$JPY_BASE_URL \
-                           --hub-prefix=$JPY_HUB_PREFIX \
-                           --hub-api-url=$JPY_HUB_API_URL'
+                        && /usr/local/bin/python3 -I -m jupyterhub.singleuser'


### PR DESCRIPTION
As part of the upgrade of the JH version in https://github.com/swan-cern/jupyterhub-extensions/pull/82

Requires swan-cern/notebook-image/pull/15 to be merged and a new version tagged.

This PR removes the extra params that are not necessary because JH already sets and retrieves the information that it needs.
The newer version uses `jupyter-server` by default, which is incompatible with out packages, so we forced it to run the old notebook backend.